### PR TITLE
Enable JWST cloud access

### DIFF
--- a/spectroscopy/spectra_generator.md
+++ b/spectroscopy/spectra_generator.md
@@ -262,12 +262,13 @@ df_spec.append(df_spec_HST)
 df_jwst = JWST_get_spec(
     sample_table,
     search_radius_arcsec=0.5,
-    datadir="./data/",
-    verbose=False,
-    delete_downloaded_data=True
+    verbose=False
 )
 df_spec.append(df_jwst)
 ```
+
+JWST spectra are now read directly from cloud storage, so no download
+directory is required.
 
 ### 2.3 ESA Archive
 


### PR DESCRIPTION
## Summary
- load JWST spectra directly from cloud URIs instead of downloading files
- document new JWST workflow
- remove deprecated `datadir` argument from JWST helpers
- drop `delete_downloaded_data` parameter from `JWST_get_spec_helper`

## Testing
- `python -m py_compile spectroscopy/code_src/mast_functions.py`
- `find spectroscopy/code_src -name '*.py' -print0 | xargs -0 python -m py_compile`


------
https://chatgpt.com/codex/tasks/task_e_685d969af8e0832a86f97d6dd100aa07